### PR TITLE
pickling support & tests added

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,11 @@ import unittest
 import twobitreader
 import os
 import sys
+import pickle
+if sys.version_info < (3,):
+    from cStringIO import StringIO
+else:
+    from io import BytesIO as StringIO
 
 
 class HasLongTypeTestCase(unittest.TestCase):
@@ -202,3 +207,14 @@ class CheckTestTwoBitFileTest(unittest.TestCase):
             found = t["chr10"][start:end]
             self.assertEqual(found, expected,
                              "__getitem__ failed on [%s:%s]. Expected %s, got %s" % (start, end, expected, found))
+
+    def test_pickle(self):
+        t = twobitreader.TwoBitFile(self.filename)
+        buf = StringIO()
+        pickle.dump(t,buf)
+        buf.seek(0)
+        t2 = pickle.load(buf)
+        self.assertListEqual(sorted(t.keys()),sorted(t2.keys()))
+        for k in t:
+            self.assertEqual(str(t[k]),str(t2[k]))
+

--- a/twobitreader/__init__.py
+++ b/twobitreader/__init__.py
@@ -243,6 +243,9 @@ See TwoBitSequence for more info
                                         self._byteswapped)
         return
 
+    def __reduce__(self): # enables pickling
+        return (TwoBitFile,(self._filename,))
+
     def _load_header(self):
         file_handle = self._file_handle
         header = array(LONG)


### PR DESCRIPTION
very small change to enable pickling support (e.g. for multiprocessing). Tested under Python 2.7 & 3.4
