### PR TITLE
Remove random print() statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 # command to install dependencies
 install: "python setup.py install"
 # command to run tests

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except ImportError:
     pass
 
 name = 'twobitreader'
-version = "3.1.0"
+version = "3.1.1"
 
 
 def main():
@@ -60,6 +60,7 @@ def main():
             'Programming Language :: Python :: 3.2',
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
             'Topic :: Scientific/Engineering :: Bio-Informatics'
         ]
     )

--- a/twobitreader/__init__.py
+++ b/twobitreader/__init__.py
@@ -132,7 +132,6 @@ TWOBYTE_TABLE = create_twobyte_table()
 
 def longs_to_char_array(longs, first_base_offset, last_base_offset, array_size,
                         more_bytes=None):
-    if more_bytes is not None: print(array('B', more_bytes))
     """
     takes in an array of longs (4 bytes) and converts them to bases in
     a char array


### PR DESCRIPTION
I'd like to use twobitreader in one of our projects, but the random `print()` in `longs_to_char_array()` breaks nose tests and will inevitably confuse some of our users. This PR removes that and also adds python 3.5 to the list of supported versions and runs the nose tests on it.
