### PR TITLE
Prevent crashes when fetching sequences at the very end of a 2bit file

### DIFF
--- a/twobitreader/__init__.py
+++ b/twobitreader/__init__.py
@@ -166,14 +166,16 @@ def longs_to_char_array(longs, first_base_offset, last_base_offset, array_size,
     dna = array(_CHAR_CODE, 'N' * (longs_len * 16 + 4 * shorts_length))
     # translate from 32-bit blocks to bytes
     # this method ensures correct endianess (byteswap as neeed)
-    bytes_ = array('B')
-    bytes_.fromstring(longs.tostring())
-    # first block
-    first_block = ''.join([''.join(BYTE_TABLE[bytes_[x]]) for x in range(4)])
-    i = 16 - first_base_offset
-    if array_size < i:
-        i = array_size
-    dna[0:i] = array(_CHAR_CODE, first_block[first_base_offset:first_base_offset + i])
+    i = 0
+    if longs_len > 0:
+        bytes_ = array('B')
+        bytes_.fromstring(longs.tostring())
+        # first block
+        first_block = ''.join([''.join(BYTE_TABLE[bytes_[x]]) for x in range(4)])
+        i = 16 - first_base_offset
+        if array_size < i:
+            i = array_size
+        dna[0:i] = array(_CHAR_CODE, first_block[first_base_offset:first_base_offset + i])
     if longs_len > 1:
         # middle blocks (implicitly skipped if they don't exist)
         for byte in bytes_[4:-4]:


### PR DESCRIPTION
This PR fixes a bug wherein querying a sequence block < 4 bytes from the end of a file causes a crash.

I'm attaching a small file that demonstrates this (ignore the `.zip` file extension, it's not actually zipped, github won't allow the attachment otherwise.

```
 python -c "import twobitreader; t = twobitreader.TwoBitFile('sequence.2bit'); print(t['chr2L'][992:1010])"
```

> Traceback (most recent call last):
>   File "<string>", line 1, in <module>
>   File "/home/ryan/.local/lib/python2.7/site-packages/twobitreader/**init**.py", line 397, in **getitem**
>     return self.get_slice(min_=slice_or_key.start, max_=slice_or_key.stop)
>   File "/home/ryan/.local/lib/python2.7/site-packages/twobitreader/**init**.py", line 482, in get_slice
>     more_bytes=morebytes)
>   File "/home/ryan/.local/lib/python2.7/site-packages/twobitreader/**init**.py", line 172, in longs_to_char_array
>     first_block = ''.join([''.join(BYTE_TABLE[bytes_[x]]) for x in range(4)])
> IndexError: array index out of range

With the PR, this correctly returns the sequence.

[sequence.2bit.zip](https://github.com/benjschiller/twobitreader/files/197176/sequence.2bit.zip)
