### PR TITLE
Fixed "long is not defined" error for Python 3

### DIFF
--- a/twobitreader/__init__.py
+++ b/twobitreader/__init__.py
@@ -29,6 +29,7 @@ if at_least_py3:
     xrange = range
     _CHAR_CODE = 'u'
     iteritems = dict.items
+    long = int
 else:
     from itertools import izip
 


### PR DESCRIPTION
"PEP 237 -- Unifying Long Integers and Integers"