### PR TITLE
Updated python versions for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 # command to install dependencies
 install: "python setup.py install"
 # command to run tests


### PR DESCRIPTION
Travis CI fails to download python 3.2 and 3.3. Python 3.3 did not get security fixes since 2017-09-29. On the other hand, the current version is 3.8. So it might be time to update the Python versions in the .travis.yml.